### PR TITLE
Add #getUsersLookup() and fix #getUsers()

### DIFF
--- a/src/Thujohn/Twitter/Twitter.php
+++ b/src/Thujohn/Twitter/Twitter.php
@@ -678,7 +678,7 @@ class Twitter extends tmhOAuth {
 	 * - include_entities (0|1)
 	 */
 	public function getUsers($parameters = array()){
-		if (!array_key_exists('id', $parameters) && !array_key_exists('screen_name', $parameters)){
+		if (!array_key_exists('user_id', $parameters) && !array_key_exists('screen_name', $parameters)){
 			throw new \Exception('Parameter required missing : id or screen_name');
 		}
 
@@ -686,6 +686,23 @@ class Twitter extends tmhOAuth {
 
 		return json_decode($response);
 	}
+
+  /**
+   * Prameters :
+   * - user_id
+   * - screen_name
+   * - include_entities (0|1)
+   */
+  public function getUsersLookup($parameters = array()) {
+    if (!array_key_exists('screen_name', $parameters)
+        && !array_key_exists('user_id', $parameters)) {
+      throw new \Exception("Paramter required missing : user_id or screen_name");
+    }
+
+    $response = $this->query('users/lookup', 'GET', 'json', $parameters);
+
+    return json_decode($response);
+  }
 
 	/**
 	 * Parameters :

--- a/tests/Thujohn/Twitter/TwitterTest.php
+++ b/tests/Thujohn/Twitter/TwitterTest.php
@@ -11,13 +11,13 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
                     ->getMock();
     }
 
-    protected function getTwitterExpecting(array $queryParams)
+    protected function getTwitterExpecting($endpoint, array $queryParams)
     {
         $twitter = $this->getTwitter();
         $twitter->expects($this->once())
                 ->method('query')
                 ->with(
-                    $this->anything(),
+                    $endpoint,
                     $this->anything(),
                     $this->anything(),
                     $queryParams
@@ -27,7 +27,7 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
 
     public function testGetUsersWithScreenName()
     {
-        $twitter = $this->getTwitterExpecting(array(
+        $twitter = $this->getTwitterExpecting('users/show', array(
             'screen_name' => 'my_screen_name'
         ));
 
@@ -38,12 +38,58 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
 
     public function testGetUsersWithId()
     {
-        $twitter = $this->getTwitterExpecting(array(
-            'id' => 1234567890
+        $twitter = $this->getTwitterExpecting('users/show', array(
+            'user_id' => 1234567890
         ));
 
         $twitter->getUsers(array(
-            'id' => 1234567890
+            'user_id' => 1234567890
+        ));
+    }
+
+    /**
+     * @expectedException Exception
+     */
+    public function testGetUsersInvalid()
+    {
+        $twitter = $this->getTwitter();
+
+        $twitter->getUsers(array(
+            'include_entities' => true
+        ));
+    }
+
+    public function testGetUsersLookupWithIds()
+    {
+        $twitter = $this->getTwitterExpecting('users/lookup', array(
+            'user_id' => '1,2,3,4'
+        ));
+
+        $twitter->getUsersLookup(array(
+            'user_id' => implode(',', array(1, 2, 3, 4))
+        ));
+    }
+
+    public function testGetUsersLookupWithScreenNames()
+    {
+        $twitter = $this->getTwitterExpecting('users/lookup', array(
+            'screen_name' => 'me,you,everybody'
+        ));
+
+        $twitter->getUsersLookup(array(
+            'screen_name' => implode(',', array('me', 'you', 'everybody'))
+        ));
+    }
+
+    /**
+     * @expectedException Exception
+     */
+    public function testGetUsersLookupInvalid()
+    {
+        $twitter = $this->getTwitter();
+
+        $twitter->getUsersLookup(array(
+            'include_entities' => true
         ));
     }
 }


### PR DESCRIPTION
Get users was previously throwing an error when you omitted either `user_id` OR `screen_name` (not AND), and I added support for the [`users/lookup`](https://dev.twitter.com/docs/api/1.1/get/users/show) endpoint. Also, `#getUsers()` erroneously required an `id` parameter, not `user_id` ([ref](https://dev.twitter.com/docs/api/1.1/get/users/show)).

I also laid the groundwork for some testing of this package, as well as a few tests supporting my changes.  Maybe this can be flushed out?

The `composer.json` doesn't list `phpunit` as a dependency (despite the presence of a `phpunit.xml`), so I'm not sure what versions are used elsewhere, but all tests currently pass under PHPUnit `3.7.24-4-g780cdb1` with PHP `5.3.10`.
