### PR TITLE
fix travis build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 
 php: 
-  - 5.3
   - 5.4
+  - 5.5
 
 before_script:
   - curl -s http://getcomposer.org/installer | php


### PR DESCRIPTION
Laravel requires PHP 5.4. Testing for PHP 5.5 is recommended.
