### PR TITLE
Properly corrects regex for hastags

### DIFF
--- a/src/Thujohn/Twitter/Twitter.php
+++ b/src/Thujohn/Twitter/Twitter.php
@@ -165,7 +165,7 @@ class Twitter extends tmhOAuth {
 		$patterns['url']      = '(?xi)\b((?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:\'".,<>?«»“”‘’]))';
 		$patterns['mailto']   = '(([a-z0-9_]|\\-|\\.)+@([^[:space:]]*)([[:alnum:]-]))';
 		$patterns['user']     = ' +@([a-z0-9_]*)?';
-		$patterns['hashtag']  = '(?:(?<=\s)|^)#(\w*[A-Za-z_\p{Cyrillic}\d]+\w*)';
+		$patterns['hashtag']  = '(?:(?<=\s)|^)#(\w*[\p{L}-\d\p{Cyrillic}\d]+\w*)';
 		$patterns['long_url'] = '>(([[:alnum:]]+:\/\/)|www\.)?([^[:space:]]{12,22})([^[:space:]]*)([^[:space:]]{12,22})([[:alnum:]#?\/&=])<';
 
 		// URL


### PR DESCRIPTION
Updated hash linkify function to properly linkify cyrillic and Swedish characters.

Fixes issue #23
