### PR TITLE
Fix valid parameter checks

### DIFF
--- a/src/Thujohn/Twitter/Twitter.php
+++ b/src/Thujohn/Twitter/Twitter.php
@@ -1312,7 +1312,7 @@ class Twitter extends tmhOAuth {
 	 */
 	public function getListMembers($parameters = array())
 	{
-		if (!array_key_exists('list_id', $parameters) || !array_key_exists('slug', $parameters))
+		if (!array_key_exists('list_id', $parameters) && !array_key_exists('slug', $parameters))
 		{
 			throw new \Exception('Parameter required missing : list_id or slug');
 		}
@@ -1411,7 +1411,7 @@ class Twitter extends tmhOAuth {
 	 */
 	public function getList($parameters = array())
 	{
-		if (!array_key_exists('list_id', $parameters) || !array_key_exists('slug', $parameters))
+		if (!array_key_exists('list_id', $parameters) && !array_key_exists('slug', $parameters))
 		{
 			throw new \Exception('Parameter required missing : list_id or slug');
 		}


### PR DESCRIPTION
lists/show and lists/subscribers can accept a list_id OR and slug. Both parameters should not exist for the method to throw an exception.

Probably needs fixing for other methods as well.
