### PR TITLE
getListsStatuses bug: list_id or slug

### DIFF
--- a/src/Thujohn/Twitter/Twitter.php
+++ b/src/Thujohn/Twitter/Twitter.php
@@ -1142,7 +1142,7 @@ class Twitter extends tmhOAuth {
 	 */
 	public function getListsStatuses($parameters = array())
 	{
-		if (!array_key_exists('list_id', $parameters) || !array_key_exists('slug', $parameters))
+		if (!array_key_exists('list_id', $parameters) && !array_key_exists('slug', $parameters))
 		{
 			throw new \Exception('Parameter required missing : list_id or slug');
 		}


### PR DESCRIPTION
getListsStatuses was throwing exception when list_id parameter was missing, even if slug paramter was specified
