### PR TITLE
Renaming set_new_config method to CamelCase and refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Route::get('/twitter/login', function()
 	$force_login = FALSE;
 	$callback_url = 'http://' . $_SERVER['HTTP_HOST'] . '/twitter/callback';
 	// Make sure we make this request w/o tokens, overwrite the default values in case of login.
-	Twitter::set_new_config(array('token' => '', 'secret' => ''));
+	Twitter::setNewConfig(array('token' => '', 'secret' => ''));
 	$token = Twitter::getRequestToken($callback_url);
 	if( isset( $token['oauth_token_secret'] ) ) {
 		$url = Twitter::getAuthorizeURL($token, $sign_in_twitter, $force_login);
@@ -138,7 +138,7 @@ Route::get('/twitter/callback', function() {
 			'secret' => Session::get('oauth_request_token_secret'),
 		);
 
-		Twitter::set_new_config($request_token);
+		Twitter::setNewConfig($request_token);
 
 		$oauth_verifier = FALSE;
 		if(Input::has('oauth_verifier')) {


### PR DESCRIPTION
Hi.
I renamed method set_new_config to setNewConfig and created const for method POST\GET request.
Also I refactored your method getAuthorizeURL and removed unnecessary code.

Example:
<pre>
$response = $this->query('application/rate_limit_status', 'GET', $parameters);

return $response;
</pre>

to

<pre>
return $this->query('application/rate_limit_status', self::METHOD_GET, $parameters);
</pre>