### PR TITLE
Fixing twitter media upload API parameters validation.

### DIFF
--- a/src/Thujohn/Twitter/Traits/MediaTrait.php
+++ b/src/Thujohn/Twitter/Traits/MediaTrait.php
@@ -12,10 +12,12 @@ Trait MediaTrait {
 	 */
 	public function uploadMedia($parameters = [])
 	{
-		if (!array_key_exists('media', $parameters))
-		{
-			throw new Exception('Parameter required missing : media');
-		}
+        if (!array_key_exists('media', $parameters) || !array_key_exists('media_data', $parameters)) {
+            throw new Exception('Parameter required missing : media or media_data');
+        }
+        if (array_key_exists('media', $parameters) && array_key_exists('media_data', $parameters)) {
+            throw new Exception('You cannot use media and media_data at the same time');
+        }
 
 		return $this->post('media/upload', $parameters, true);
 	}


### PR DESCRIPTION
According to the Twitter API [documentation](https://dev.twitter.com/rest/reference/post/media/upload), you can either pass `media` or `media_data` parameters when uploading an image, but not both at the same time. 
Fixed this validation.