### PR TITLE
Add conditional for 503 error

### DIFF
--- a/src/Thujohn/Twitter/Twitter.php
+++ b/src/Thujohn/Twitter/Twitter.php
@@ -267,6 +267,10 @@ class Twitter extends tmhOAuth {
 			$this->log('ERROR_MSG : '.$response['error']);
 		}
 
+		if ($response['code'] === 503) {
+			throw new Exception('Service Unavailable', $response['code']);
+		}
+
 		if (isset($response['code']) && $response['code'] != 200)
 		{
 			$_response = $this->jsonDecode($response['response'], true);


### PR DESCRIPTION
Currently the line (276)
    `$_response = $this->jsonDecode($response['response'], true);`

is failing due to `$response['response']` not existing.

I've added a conditional to throw an exception for a 503 error.