### PR TITLE
Update TwitterServiceProvider.php

### DIFF
--- a/src/Thujohn/Twitter/TwitterServiceProvider.php
+++ b/src/Thujohn/Twitter/TwitterServiceProvider.php
@@ -46,10 +46,11 @@ class TwitterServiceProvider extends ServiceProvider {
 			$this->package('thujohn/twitter', 'ttwitter', __DIR__.'/../..');
 		}
 
-		$this->app['ttwitter'] = $this->app->share(function($app)
+		$this->app['Thujohn\Twitter\Twitter'] = $this->app->share(function($app)
 		{
 			return new Twitter($app['config'], $app['session.store']);
 		});
+		$this->app->bind('ttwitter', 'Thujohn\Twitter\Twitter');
 	}
 
 	/**


### PR DESCRIPTION
Not all users would like to use the Facade to access this class. This simple change will provide both types of support. Users may either access all current methods via facade, or as a concrete dependency.