### PR TITLE
Change publish command so it only publishes the package files

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Also, make sure to remove the env in the config file and replace it with your in
 
 ## Configuration (Laravel 5)
 
-Run `php artisan vendor:publish` and modify the config file with your own information.
+Run `php artisan vendor:publish --provider="Thujohn\Twitter\TwitterServiceProvider"` and modify the config file with your own information.
 ```
 /config/ttwitter.php
 ```


### PR DESCRIPTION
By using the --provider option on the vendor:publish command we can indicate the Service Provider for which we want configuration files to be published, avoiding publish files from other packages that the user might or might not want.
