### PR TITLE
Make upload/media work with chunk

### DIFF
--- a/src/Thujohn/Twitter/Twitter.php
+++ b/src/Thujohn/Twitter/Twitter.php
@@ -267,7 +267,7 @@ class Twitter extends tmhOAuth {
 			$this->log('ERROR_MSG : '.$response['error']);
 		}
 
-		if (isset($response['code']) && $response['code'] != 200)
+		 if (isset($response['code']) && !in_array($response['code'], [200, 201, 202, 204]))
 		{
 			$_response = $this->jsonDecode($response['response'], true);
 


### PR DESCRIPTION
Want to use https://dev.twitter.com/rest/reference/post/media/upload-chunked but as return code is not exactly 200, it will not work.

Code look like this 
```php

                    // INIT
                    $response = TT::uploadMedia([
                        'command' => 'INIT',
                        'total_bytes' => $left,
                        'media_type' => $type[0],
                        'media' => ''
                    ]);

                    $media_id = $response->media_id;

                    // APPEND
                    foreach ($contents as $i => $c) {

                        \Log::info('goi pour ' .  $i);
                        TT::uploadMedia([
                            'command' => 'APPEND',
                            'media_id' => $media_id,
                            'media_data' => $c,
                            'segment_index' =>$i
                        ]);
                    }

                    // FINALIZE
                    $response = TT::uploadMedia([
                        'command' => 'FINALIZE',
                        'media_id' => $media_id,
                        'media' => ''
                    ]);

```