### PR TITLE
Fix php version required by 2.1.4+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.5.0",
         "illuminate/support": "4.*|5.*",
         "themattharris/tmhoauth": "0.8.4"
     },


### PR DESCRIPTION
PHP version required is 5.5 at least to work with `Class::class`.
See thujohn@762afe9.
See http://php.net/manual/en/language.oop5.basic.php#language.oop5.basic.class.class.
