### PR TITLE
Be more explicit about what we are publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Also, make sure to remove the env in the config file and replace it with your in
 
 ## Configuration (Laravel 5)
 
-Run `php artisan vendor:publish` and modify the config file with your own information.
+Run `php artisan vendor:publish --provider="Thujohn\\Twitter\\TwitterServiceProvider"` and modify the config file with your own information.
 ```
 /config/ttwitter.php
 ```


### PR DESCRIPTION
The instructions for Laravel 5 suggest publishing the config without limiting to this package. 

```
$ php artisan vendor:publish
```

This PR updates the docs to be specific about what we want to publish, e.g.

```
php artisan vendor:publish --provider="Thujohn\\Twitter\\TwitterServiceProvider"
```
