### PR TITLE
Use singleton instead of share for Laravel 5.4 compatibility

### DIFF
--- a/src/Thujohn/Twitter/TwitterServiceProvider.php
+++ b/src/Thujohn/Twitter/TwitterServiceProvider.php
@@ -61,16 +61,21 @@ class TwitterServiceProvider extends ServiceProvider {
 					__DIR__.'/../../config/config.php' => config_path('ttwitter.php'),
 				]);
 			}
+			
+			$this->app->singleton(Twitter::class, function($app)
+			{
+			    return new Twitter($app['config'], $app['session.store']);
+			});
 		}
 		else if ($laravelVersion == 4)
 		{
 			$this->package('thujohn/twitter', 'ttwitter', __DIR__.'/../..');
+			
+			$this->app[Twitter::class] = $this->app->share(function($app)
+			{
+			    return new Twitter($app['config'], $app['session.store']);
+			});
 		}
-
-		$this->app[Twitter::class] = $this->app->share(function($app)
-		{
-			return new Twitter($app['config'], $app['session.store']);
-		});
 	}
 
 	/**


### PR DESCRIPTION
On upgrading the Laravel 5.4, the share() method no longer works. Have replaced with singleton() registration for Laravel 5 applications. Not sure if same would work for Laravel 4, so have left as was for Laravel 4 applications.