### PR TITLE
Fix reference to include_email param

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Route::get('/', function()
 Get User Credentials with email.
 ```
 $credentials = Twitter::getCredentials([
-    'email' => 'true',
+    'include_email' => 'true',
 ]);
 ```
 > In the above, you need to pass true as a string, not as a boolean. The boolean will get converted to `1` which Twitter ignores.


### PR DESCRIPTION
The current documentation suggests calling:

```php
$credentials = Twitter::getCredentials([
    'email' => 'true',
]);
```

to get the user's email address. The correct array key is actually `include_email`. This PR corrects it. 

