### PR TITLE
Changed exceptions to be more specific ones provided by PHP's SPL.

### DIFF
--- a/src/Thujohn/Twitter/Traits/AccountTrait.php
+++ b/src/Thujohn/Twitter/Traits/AccountTrait.php
@@ -1,6 +1,6 @@
 <?php namespace Thujohn\Twitter\Traits;
 
-use Exception;
+use BadMethodCallException;
 
 Trait AccountTrait {
 
@@ -39,7 +39,7 @@ Trait AccountTrait {
 	{
 		if (empty($parameters))
 		{
-			throw new Exception('Parameter missing');
+			throw new BadMethodCallException('Parameter missing');
 		}
 
 		return $this->post('account/settings', $parameters);
@@ -56,7 +56,7 @@ Trait AccountTrait {
 	{
 		if (!array_key_exists('device', $parameters))
 		{
-			throw new Exception('Parameter required missing : device');
+			throw new BadMethodCallException('Parameter required missing : device');
 		}
 
 		return $this->post('account/update_delivery_device', $parameters);
@@ -77,7 +77,7 @@ Trait AccountTrait {
 	{
 		if (empty($parameters))
 		{
-			throw new Exception('Parameter missing');
+			throw new BadMethodCallException('Parameter missing');
 		}
 
 		return $this->post('account/update_profile', $parameters);
@@ -97,7 +97,7 @@ Trait AccountTrait {
 	{
 		if (!array_key_exists('image', $parameters) && !array_key_exists('tile', $parameters) && !array_key_exists('use', $parameters))
 		{
-			throw new Exception('Parameter required missing : image, tile or use');
+			throw new BadMethodCallException('Parameter required missing : image, tile or use');
 		}
 
 		return $this->post('account/update_profile_background_image', $parameters, true);
@@ -115,7 +115,7 @@ Trait AccountTrait {
 	{
 		if (!array_key_exists('image', $parameters))
 		{
-			throw new Exception('Parameter required missing : image');
+			throw new BadMethodCallException('Parameter required missing : image');
 		}
 
 		return $this->post('account/update_profile_image', $parameters, true);
@@ -142,7 +142,7 @@ Trait AccountTrait {
 	public function postUserBanner($parameters = [])
 	{
 		if (!array_key_exists('banner', $parameters)){
-			throw new Exception('Parameter required missing : banner');
+			throw new BadMethodCallException('Parameter required missing : banner');
 		}
 
 		return $this->post('account/update_profile_banner', $parameters);

--- a/src/Thujohn/Twitter/Traits/BlockTrait.php
+++ b/src/Thujohn/Twitter/Traits/BlockTrait.php
@@ -1,6 +1,6 @@
 <?php namespace Thujohn\Twitter\Traits;
 
-use Exception;
+use BadMethodCallException;
 
 Trait BlockTrait {
 
@@ -42,7 +42,7 @@ Trait BlockTrait {
 	{
 		if (!array_key_exists('screen_name', $parameters) && !array_key_exists('user_id', $parameters))
 		{
-			throw new Exception('Parameter required missing : screen_name or user_id');
+			throw new BadMethodCallException('Parameter required missing : screen_name or user_id');
 		}
 
 		return $this->post('blocks/create', $parameters);
@@ -61,7 +61,7 @@ Trait BlockTrait {
 	{
 		if (!array_key_exists('screen_name', $parameters) && !array_key_exists('user_id', $parameters))
 		{
-			throw new Exception('Parameter required missing : screen_name or user_id');
+			throw new BadMethodCallException('Parameter required missing : screen_name or user_id');
 		}
 
 		return $this->post('blocks/destroy', $parameters);

--- a/src/Thujohn/Twitter/Traits/DirectMessageTrait.php
+++ b/src/Thujohn/Twitter/Traits/DirectMessageTrait.php
@@ -1,6 +1,6 @@
 <?php namespace Thujohn\Twitter\Traits;
 
-use Exception;
+use BadMethodCallException;
 
 Trait DirectMessageTrait {
 
@@ -29,7 +29,7 @@ Trait DirectMessageTrait {
 	{
 		if (!array_key_exists('id', $parameters))
 		{
-			throw new Exception('Parameter required missing : id');
+			throw new BadMethodCallException('Parameter required missing : id');
 		}
 
 		return $this->get('direct_messages/show', $parameters);
@@ -61,7 +61,7 @@ Trait DirectMessageTrait {
 	{
 		if (!array_key_exists('id', $parameters))
 		{
-			throw new Exception('Parameter required missing : id');
+			throw new BadMethodCallException('Parameter required missing : id');
 		}
 
 		return $this->post('direct_messages/destroy', $parameters);
@@ -79,7 +79,7 @@ Trait DirectMessageTrait {
 	{
 		if ((!array_key_exists('user_id', $parameters) && !array_key_exists('screen_name', $parameters)) || !array_key_exists('text', $parameters))
 		{
-			throw new Exception('Parameter required missing : user_id, screen_name or text');
+			throw new BadMethodCallException('Parameter required missing : user_id, screen_name or text');
 		}
 
 		return $this->post('direct_messages/new', $parameters);

--- a/src/Thujohn/Twitter/Traits/FavoriteTrait.php
+++ b/src/Thujohn/Twitter/Traits/FavoriteTrait.php
@@ -1,6 +1,6 @@
 <?php namespace Thujohn\Twitter\Traits;
 
-use Exception;
+use BadMethodCallException;
 
 Trait FavoriteTrait {
 
@@ -31,7 +31,7 @@ Trait FavoriteTrait {
 	{
 		if (!array_key_exists('id', $parameters))
 		{
-			throw new Exception('Parameter required missing : id');
+			throw new BadMethodCallException('Parameter required missing : id');
 		}
 
 		return $this->post('favorites/destroy', $parameters);
@@ -48,7 +48,7 @@ Trait FavoriteTrait {
 	{
 		if (!array_key_exists('id', $parameters))
 		{
-			throw new Exception('Parameter required missing : id');
+			throw new BadMethodCallException('Parameter required missing : id');
 		}
 
 		return $this->post('favorites/create', $parameters);

--- a/src/Thujohn/Twitter/Traits/FriendshipTrait.php
+++ b/src/Thujohn/Twitter/Traits/FriendshipTrait.php
@@ -1,6 +1,6 @@
 <?php namespace Thujohn\Twitter\Traits;
 
-use Exception;
+use BadMethodCallException;
 
 Trait FriendshipTrait {
 
@@ -81,7 +81,7 @@ Trait FriendshipTrait {
 	{
 		if (!array_key_exists('screen_name', $parameters) && !array_key_exists('user_id', $parameters))
 		{
-			throw new Exception('Parameter required missing : screen_name or user_id');
+			throw new BadMethodCallException('Parameter required missing : screen_name or user_id');
 		}
 
 		return $this->post('friendships/create', $parameters);
@@ -98,7 +98,7 @@ Trait FriendshipTrait {
 	{
 		if (!array_key_exists('screen_name', $parameters) && !array_key_exists('user_id', $parameters))
 		{
-			throw new Exception('Parameter required missing : screen_name or user_id');
+			throw new BadMethodCallException('Parameter required missing : screen_name or user_id');
 		}
 
 		return $this->post('friendships/destroy', $parameters);
@@ -117,7 +117,7 @@ Trait FriendshipTrait {
 	{
 		if (!array_key_exists('screen_name', $parameters) && !array_key_exists('user_id', $parameters))
 		{
-			throw new Exception('Parameter required missing : screen_name or user_id');
+			throw new BadMethodCallException('Parameter required missing : screen_name or user_id');
 		}
 
 		return $this->post('friendships/update', $parameters);
@@ -136,7 +136,7 @@ Trait FriendshipTrait {
 	{
 		if (!array_key_exists('target_id', $parameters) && !array_key_exists('target_screen_name', $parameters))
 		{
-			throw new Exception('Parameter required missing : target_id or target_screen_name');
+			throw new BadMethodCallException('Parameter required missing : target_id or target_screen_name');
 		}
 
 		return $this->get('friendships/show', $parameters);

--- a/src/Thujohn/Twitter/Traits/GeoTrait.php
+++ b/src/Thujohn/Twitter/Traits/GeoTrait.php
@@ -1,6 +1,6 @@
 <?php namespace Thujohn\Twitter\Traits;
 
-use Exception;
+use BadMethodCallException;
 
 Trait GeoTrait {
 
@@ -27,7 +27,7 @@ Trait GeoTrait {
 	{
 		if (!array_key_exists('lat', $parameters) || !array_key_exists('long', $parameters))
 		{
-			throw new Exception('Parameter required missing : lat or long');
+			throw new BadMethodCallException('Parameter required missing : lat or long');
 		}
 
 		return $this->get('geo/reverse_geocode', $parameters);
@@ -68,7 +68,7 @@ Trait GeoTrait {
 	{
 		if (!array_key_exists('lat', $parameters) || !array_key_exists('long', $parameters) || !array_key_exists('name', $parameters))
 		{
-			throw new Exception('Parameter required missing : lat, long or name');
+			throw new BadMethodCallException('Parameter required missing : lat, long or name');
 		}
 
 		return $this->get('geo/similar_places', $parameters);

--- a/src/Thujohn/Twitter/Traits/HelpTrait.php
+++ b/src/Thujohn/Twitter/Traits/HelpTrait.php
@@ -1,6 +1,6 @@
 <?php namespace Thujohn\Twitter\Traits;
 
-use Exception;
+use BadMethodCallException;
 
 Trait HelpTrait {
 
@@ -15,7 +15,7 @@ Trait HelpTrait {
 	{
 		if (empty($parameters))
 		{
-			throw new Exception('Parameter missing : screen_name or user_id');
+			throw new BadMethodCallException('Parameter missing : screen_name or user_id');
 		}
 
 		return $this->post('users/report_spam', $parameters);

--- a/src/Thujohn/Twitter/Traits/ListTrait.php
+++ b/src/Thujohn/Twitter/Traits/ListTrait.php
@@ -1,6 +1,6 @@
 <?php namespace Thujohn\Twitter\Traits;
 
-use Exception;
+use BadMethodCallException;
 
 Trait ListTrait {
 
@@ -35,7 +35,7 @@ Trait ListTrait {
 	{
 		if (!array_key_exists('list_id', $parameters) && !array_key_exists('slug', $parameters))
 		{
-			throw new Exception('Parameter required missing : list_id or slug');
+			throw new BadMethodCallException('Parameter required missing : list_id or slug');
 		}
 
 		return $this->get('lists/statuses', $parameters);
@@ -56,12 +56,12 @@ Trait ListTrait {
 	{
 		if (!array_key_exists('list_id', $parameters) && !array_key_exists('slug', $parameters))
 		{
-			throw new Exception('Parameter required missing : list_id or slug');
+			throw new BadMethodCallException('Parameter required missing : list_id or slug');
 		}
 
 		if (array_key_exists('slug', $parameters) && (!array_key_exists('owner_screen_name', $parameters) && !array_key_exists('owner_id', $parameters)))
 		{
-			throw new Exception('Parameter required missing : owner_screen_name or owner_id');
+			throw new BadMethodCallException('Parameter required missing : owner_screen_name or owner_id');
 		}
 
 		return $this->post('lists/members/destroy', $parameters);
@@ -98,7 +98,7 @@ Trait ListTrait {
 	{
 		if (!array_key_exists('list_id', $parameters) && !array_key_exists('slug', $parameters))
 		{
-			throw new Exception('Parameter required missing : list_id or slug');
+			throw new BadMethodCallException('Parameter required missing : list_id or slug');
 		}
 
 		return $this->get('lists/subscribers', $parameters);
@@ -117,12 +117,12 @@ Trait ListTrait {
 	{
 		if (!array_key_exists('list_id', $parameters) && !array_key_exists('slug', $parameters))
 		{
-			throw new Exception('Parameter required missing : list_id or slug');
+			throw new BadMethodCallException('Parameter required missing : list_id or slug');
 		}
 
 		if (array_key_exists('slug', $parameters) && (!array_key_exists('owner_screen_name', $parameters) && !array_key_exists('owner_id', $parameters)))
 		{
-			throw new Exception('Parameter required missing : owner_screen_name or owner_id');
+			throw new BadMethodCallException('Parameter required missing : owner_screen_name or owner_id');
 		}
 
 		return $this->post('lists/subscribers/create', $parameters);
@@ -145,12 +145,12 @@ Trait ListTrait {
 	{
 		if (!array_key_exists('list_id', $parameters) && !array_key_exists('slug', $parameters))
 		{
-			throw new Exception('Parameter required missing : list_id or slug');
+			throw new BadMethodCallException('Parameter required missing : list_id or slug');
 		}
 
 		if (array_key_exists('slug', $parameters) && (!array_key_exists('owner_screen_name', $parameters) && !array_key_exists('owner_id', $parameters)))
 		{
-			throw new Exception('Parameter required missing : owner_screen_name or owner_id');
+			throw new BadMethodCallException('Parameter required missing : owner_screen_name or owner_id');
 		}
 
 		return $this->get('lists/subscribers/show', $parameters);
@@ -169,7 +169,7 @@ Trait ListTrait {
 	{
 		if (!array_key_exists('list_id', $parameters) && !array_key_exists('slug', $parameters))
 		{
-			throw new Exception('Parameter required missing : list_id or slug');
+			throw new BadMethodCallException('Parameter required missing : list_id or slug');
 		}
 
 		return $this->post('lists/subscribers/destroy', $parameters);
@@ -190,7 +190,7 @@ Trait ListTrait {
 	{
 		if (!array_key_exists('list_id', $parameters) && !array_key_exists('slug', $parameters))
 		{
-			throw new Exception('Parameter required missing : list_id or slug');
+			throw new BadMethodCallException('Parameter required missing : list_id or slug');
 		}
 
 		return $this->post('lists/members/create_all', $parameters);
@@ -213,17 +213,17 @@ Trait ListTrait {
 	{
 		if (!array_key_exists('list_id', $parameters) && !array_key_exists('slug', $parameters))
 		{
-			throw new Exception('Parameter required missing : list_id or slug');
+			throw new BadMethodCallException('Parameter required missing : list_id or slug');
 		}
 
 		if (!array_key_exists('user_id', $parameters) && !array_key_exists('screen_name', $parameters))
 		{
-			throw new Exception('Parameter required missing : user_id or screen_name');
+			throw new BadMethodCallException('Parameter required missing : user_id or screen_name');
 		}
 
 		if (array_key_exists('slug', $parameters) && (!array_key_exists('owner_screen_name', $parameters) && !array_key_exists('owner_id', $parameters)))
 		{
-			throw new Exception('Parameter required missing : owner_screen_name or owner_id');
+			throw new BadMethodCallException('Parameter required missing : owner_screen_name or owner_id');
 		}
 
 		return $this->get('lists/members/show', $parameters);
@@ -245,12 +245,12 @@ Trait ListTrait {
 	{
 		if (!array_key_exists('list_id', $parameters) && !array_key_exists('slug', $parameters))
 		{
-			throw new Exception('Parameter required missing : list_id or slug');
+			throw new BadMethodCallException('Parameter required missing : list_id or slug');
 		}
 
 		if (array_key_exists('slug', $parameters) && (!array_key_exists('owner_screen_name', $parameters) && !array_key_exists('owner_id', $parameters)))
 		{
-			throw new Exception('Parameter required missing : owner_screen_name or owner_id');
+			throw new BadMethodCallException('Parameter required missing : owner_screen_name or owner_id');
 		}
 
 		return $this->get('lists/members', $parameters);
@@ -271,12 +271,12 @@ Trait ListTrait {
 	{
 		if (!array_key_exists('list_id', $parameters) && !array_key_exists('slug', $parameters))
 		{
-			throw new Exception('Parameter required missing : list_id or slug');
+			throw new BadMethodCallException('Parameter required missing : list_id or slug');
 		}
 
 		if (array_key_exists('slug', $parameters) && (!array_key_exists('owner_screen_name', $parameters) && !array_key_exists('owner_id', $parameters)))
 		{
-			throw new Exception('Parameter required missing : owner_screen_name or owner_id');
+			throw new BadMethodCallException('Parameter required missing : owner_screen_name or owner_id');
 		}
 
 		return $this->post('lists/members/create', $parameters);
@@ -295,12 +295,12 @@ Trait ListTrait {
 	{
 		if (!array_key_exists('list_id', $parameters) && !array_key_exists('slug', $parameters))
 		{
-			throw new Exception('Parameter required missing : list_id or slug');
+			throw new BadMethodCallException('Parameter required missing : list_id or slug');
 		}
 
 		if (array_key_exists('slug', $parameters) && (!array_key_exists('owner_screen_name', $parameters) && !array_key_exists('owner_id', $parameters)))
 		{
-			throw new Exception('Parameter required missing : owner_screen_name or owner_id');
+			throw new BadMethodCallException('Parameter required missing : owner_screen_name or owner_id');
 		}
 
 		return $this->post('lists/destroy', $parameters);
@@ -322,12 +322,12 @@ Trait ListTrait {
 	{
 		if (!array_key_exists('list_id', $parameters) && !array_key_exists('slug', $parameters))
 		{
-			throw new Exception('Parameter required missing : list_id or slug');
+			throw new BadMethodCallException('Parameter required missing : list_id or slug');
 		}
 
 		if (array_key_exists('slug', $parameters) && (!array_key_exists('owner_screen_name', $parameters) && !array_key_exists('owner_id', $parameters)))
 		{
-			throw new Exception('Parameter required missing : owner_screen_name or owner_id');
+			throw new BadMethodCallException('Parameter required missing : owner_screen_name or owner_id');
 		}
 
 		return $this->post('lists/update', $parameters);
@@ -345,7 +345,7 @@ Trait ListTrait {
 	{
 		if (!array_key_exists('name', $parameters))
 		{
-			throw new Exception('Parameter required missing : name');
+			throw new BadMethodCallException('Parameter required missing : name');
 		}
 
 		return $this->post('lists/create', $parameters);
@@ -364,12 +364,12 @@ Trait ListTrait {
 	{
 		if (!array_key_exists('list_id', $parameters) && !array_key_exists('slug', $parameters))
 		{
-			throw new Exception('Parameter required missing : list_id or slug');
+			throw new BadMethodCallException('Parameter required missing : list_id or slug');
 		}
 
 		if (array_key_exists('slug', $parameters) && (!array_key_exists('owner_screen_name', $parameters) && !array_key_exists('owner_id', $parameters)))
 		{
-			throw new Exception('Parameter required missing : owner_screen_name or owner_id');
+			throw new BadMethodCallException('Parameter required missing : owner_screen_name or owner_id');
 		}
 
 		return $this->get('lists/show', $parameters);
@@ -404,12 +404,12 @@ Trait ListTrait {
 	{
 		if (!array_key_exists('list_id', $parameters) && !array_key_exists('slug', $parameters))
 		{
-			throw new Exception('Parameter required missing : list_id or slug');
+			throw new BadMethodCallException('Parameter required missing : list_id or slug');
 		}
 
 		if (array_key_exists('slug', $parameters) && (!array_key_exists('owner_screen_name', $parameters) && !array_key_exists('owner_id', $parameters)))
 		{
-			throw new Exception('Parameter required missing : owner_screen_name or owner_id');
+			throw new BadMethodCallException('Parameter required missing : owner_screen_name or owner_id');
 		}
 
 		return $this->post('lists/members/destroy_all', $parameters);

--- a/src/Thujohn/Twitter/Traits/MediaTrait.php
+++ b/src/Thujohn/Twitter/Traits/MediaTrait.php
@@ -1,6 +1,6 @@
 <?php namespace Thujohn\Twitter\Traits;
 
-use Exception;
+use BadMethodCallException;
 
 Trait MediaTrait {
 
@@ -15,12 +15,12 @@ Trait MediaTrait {
 	{
 	        if (!array_key_exists('media', $parameters) && !array_key_exists('media_data', $parameters))
 	        {
-	            throw new Exception('Parameter required missing : media or media_data');
+	            throw new BadMethodCallException('Parameter required missing : media or media_data');
 	        }
 
 	        if (array_key_exists('media', $parameters) && array_key_exists('media_data', $parameters))
 	        {
-	            throw new Exception('You cannot use media and media_data at the same time');
+	            throw new BadMethodCallException('You cannot use media and media_data at the same time');
 	        }
 
 		return $this->post('media/upload', $parameters, true);

--- a/src/Thujohn/Twitter/Traits/SearchTrait.php
+++ b/src/Thujohn/Twitter/Traits/SearchTrait.php
@@ -1,6 +1,6 @@
 <?php namespace Thujohn\Twitter\Traits;
 
-use Exception;
+use BadMethodCallException;
 
 Trait SearchTrait {
 
@@ -24,7 +24,7 @@ Trait SearchTrait {
 	{
 		if (!array_key_exists('q', $parameters))
 		{
-			throw new Exception('Parameter required missing : q');
+			throw new BadMethodCallException('Parameter required missing : q');
 		}
 
 		return $this->get('search/tweets', $parameters);
@@ -56,7 +56,7 @@ Trait SearchTrait {
 	{
 		if (!array_key_exists('query', $parameters))
 		{
-			throw new Exception('Parameter required missing : query');
+			throw new BadMethodCallException('Parameter required missing : query');
 		}
 
 		return $this->post('saved_searches/create', $parameters);

--- a/src/Thujohn/Twitter/Traits/StatusTrait.php
+++ b/src/Thujohn/Twitter/Traits/StatusTrait.php
@@ -1,6 +1,6 @@
 <?php namespace Thujohn\Twitter\Traits;
 
-use Exception;
+use BadMethodCallException;
 
 Trait StatusTrait {
 
@@ -128,7 +128,7 @@ Trait StatusTrait {
 	{
 		if (!array_key_exists('status', $parameters))
 		{
-			throw new Exception('Parameter required missing : status');
+			throw new BadMethodCallException('Parameter required missing : status');
 		}
 
 		return $this->post('statuses/update', $parameters);
@@ -163,7 +163,7 @@ Trait StatusTrait {
 	{
 		if (!array_key_exists('status', $parameters) || !array_key_exists('media[]', $parameters))
 		{
-			throw new Exception('Parameter required missing : status or media[]');
+			throw new BadMethodCallException('Parameter required missing : status or media[]');
 		}
 
 		return $this->post('statuses/update_with_media', $parameters, true);
@@ -186,7 +186,7 @@ Trait StatusTrait {
 	{
 		if (!array_key_exists('id', $parameters) && !array_key_exists('url', $parameters))
 		{
-			throw new Exception('Parameter required missing : id or url');
+			throw new BadMethodCallException('Parameter required missing : id or url');
 		}
 
 		return $this->get('statuses/oembed', $parameters);
@@ -204,7 +204,7 @@ Trait StatusTrait {
 	{
 		if (!array_key_exists('id', $parameters))
 		{
-			throw new Exception('Parameter required missing : id');
+			throw new BadMethodCallException('Parameter required missing : id');
 		}
 
 		return $this->get('statuses/retweeters/ids', $parameters);
@@ -223,7 +223,7 @@ Trait StatusTrait {
 	{
 		if (!array_key_exists('id', $parameters))
 		{
-			throw new Exception('Parameter required missing : id');
+			throw new BadMethodCallException('Parameter required missing : id');
 		}
 
 		return $this->get('statuses/lookup', $parameters);

--- a/src/Thujohn/Twitter/Traits/TrendTrait.php
+++ b/src/Thujohn/Twitter/Traits/TrendTrait.php
@@ -15,7 +15,7 @@ Trait TrendTrait {
 	{
 		if (!array_key_exists('id', $parameters))
 		{
-			throw new Exception('Parameter required missing : id');
+			throw new BadMethodCallException('Parameter required missing : id');
 		}
 
 		return $this->get('trends/place', $parameters);
@@ -40,7 +40,7 @@ Trait TrendTrait {
 	{
 		if (!array_key_exists('lat', $parameters) || !array_key_exists('long', $parameters))
 		{
-			throw new Exception('Parameter required missing : lat or long');
+			throw new BadMethodCallException('Parameter required missing : lat or long');
 		}
 
 		return $this->get('trends/closest', $parameters);

--- a/src/Thujohn/Twitter/Traits/UserTrait.php
+++ b/src/Thujohn/Twitter/Traits/UserTrait.php
@@ -1,6 +1,6 @@
 <?php namespace Thujohn\Twitter\Traits;
 
-use Exception;
+use BadMethodCallException;
 
 Trait UserTrait {
 
@@ -16,7 +16,7 @@ Trait UserTrait {
 	{
 		if (!array_key_exists('user_id', $parameters) && !array_key_exists('screen_name', $parameters))
 		{
-			throw new Exception("Parameter required missing : user_id or screen_name");
+			throw new BadMethodCallException("Parameter required missing : user_id or screen_name");
 		}
 
 		return $this->get('users/lookup', $parameters);
@@ -34,7 +34,7 @@ Trait UserTrait {
 	{
 		if (!array_key_exists('user_id', $parameters) && !array_key_exists('screen_name', $parameters))
 		{
-			throw new Exception('Parameter required missing : user_id or screen_name');
+			throw new BadMethodCallException('Parameter required missing : user_id or screen_name');
 		}
 
 		return $this->get('users/show', $parameters);
@@ -53,7 +53,7 @@ Trait UserTrait {
 	{
 		if (!array_key_exists('q', $parameters))
 		{
-			throw new Exception('Parameter required missing : q');
+			throw new BadMethodCallException('Parameter required missing : q');
 		}
 
 		return $this->get('users/search', $parameters);
@@ -82,7 +82,7 @@ Trait UserTrait {
 	{
 		if (!array_key_exists('screen_name', $parameters) && !array_key_exists('user_id', $parameters))
 		{
-			throw new Exception("Parameter required missing : screen_name or user_id");
+			throw new BadMethodCallException("Parameter required missing : screen_name or user_id");
 		}
 
 		return $this->post('mutes/users/create', $parameters);
@@ -99,7 +99,7 @@ Trait UserTrait {
 	{
 		if (!array_key_exists('screen_name', $parameters) && !array_key_exists('user_id', $parameters))
 		{
-			throw new Exception("Parameter required missing : screen_name or user_id");
+			throw new BadMethodCallException("Parameter required missing : screen_name or user_id");
 		}
 
 		return $this->post('mutes/users/destroy', $parameters);

--- a/src/Thujohn/Twitter/Twitter.php
+++ b/src/Thujohn/Twitter/Twitter.php
@@ -1,6 +1,6 @@
 <?php namespace Thujohn\Twitter;
 
-use Exception;
+use RunTimeException;
 use Carbon\Carbon as Carbon;
 use Illuminate\Session\Store as SessionStore;
 use Illuminate\Config\Repository as Config;
@@ -64,7 +64,7 @@ class Twitter extends tmhOAuth {
 		}
 		else
 		{
-			throw new Exception('No config found');
+			throw new RunTimeException('No config found');
 		}
 
 		$this->debug = (isset($this->tconfig['debug']) && $this->tconfig['debug']) ? true : false;
@@ -158,7 +158,7 @@ class Twitter extends tmhOAuth {
 		}
 		else
 		{
-			throw new Exception($response['response'], $response['code']);
+			throw new RunTimeException($response['response'], $response['code']);
 		}
 	}
 
@@ -195,7 +195,7 @@ class Twitter extends tmhOAuth {
 			return $token;
 		}
 
-		throw new Exception($response['response'], $response['code']);
+		throw new RunTimeException($response['response'], $response['code']);
 	}
 
 	/**
@@ -294,7 +294,7 @@ class Twitter extends tmhOAuth {
 			$this->log('ERROR_CODE : '.$error_code);
 			$this->log('ERROR_MSG : '.$error_msg);
 
-			throw new Exception('['.$error_code.'] '.$error_msg, $response['code']);
+			throw new RunTimeException('['.$error_code.'] '.$error_msg, $response['code']);
 		}
 
 		switch ($format)


### PR DESCRIPTION
The proposed pull request contains changes which move away from the base Exception in php and aims to provide more semantic meaning to the exceptions thrown by the library.

Where possible it should be avoided to throw and catch the base Exception. This finer grained control allows developers to catch only the errors they expect to happen and allow their exception handlers to deal with those that they don't.

These changes should be backwards compatible with all code already written as all exceptions used extend the base Exception which means they will be caught by existing catch statements. Due to these backwards compatibility concerns i left the unit tests as expecting Exception (as this is what is expected to be backwards compatible).

http://php.net/manual/en/spl.exceptions.php

If there is something i've missed or something you would rather please feel free to discuss. 
Thanks, Brad.