### PR TITLE
Rename `getListsStatuses` to `getListStatuses`

### DIFF
--- a/src/Thujohn/Twitter/Traits/ListTrait.php
+++ b/src/Thujohn/Twitter/Traits/ListTrait.php
@@ -31,7 +31,7 @@ Trait ListTrait {
 	 * - include_entities (0|1)
 	 * - include_rts (0|1)
 	 */
-	public function getListsStatuses($parameters = [])
+	public function getListStatuses($parameters = [])
 	{
 		if (!array_key_exists('list_id', $parameters) && !array_key_exists('slug', $parameters))
 		{


### PR DESCRIPTION
... as this method only returns the Statuses of one specified List, not many Lists. Matches the naming of the other methods.