### PR TITLE
Change important API updates

### DIFF
--- a/src/Thujohn/Twitter/Traits/StatusTrait.php
+++ b/src/Thujohn/Twitter/Traits/StatusTrait.php
@@ -15,6 +15,7 @@ Trait StatusTrait {
 	 * - trim_user (0|1)
 	 * - contributor_details (0|1)
 	 * - include_entities (0|1)
+	 * - tweet_mode ('extended' returns a collection of Tweets, which are not truncated)
 	 */
 	public function getMentionsTimeline($parameters = [])
 	{
@@ -22,7 +23,7 @@ Trait StatusTrait {
 	}
 
 	/**
-	 * Returns a collection of the most recent Tweets posted by the user indicated by the screen_name or user_id parameters.
+	 * Returns a collection of the most recent Tweets (truncated by default) posted by the user indicated by the screen_name or user_id parameters.
 	 *
 	 * Parameters :
 	 * - user_id
@@ -35,6 +36,7 @@ Trait StatusTrait {
 	 * - exclude_replies (0|1)
 	 * - contributor_details (0|1)
 	 * - include_entities (0|1)
+	 * - tweet_mode ('extended' returns a collection of Tweets, which are not truncated)
 	 */
 	public function getUserTimeline($parameters = [])
 	{
@@ -42,7 +44,7 @@ Trait StatusTrait {
 	}
 
 	/**
-	 * Returns a collection of the most recent Tweets and retweets posted by the authenticating user and the users they follow. The home timeline is central to how most users interact with the Twitter service.
+	 * Returns a collection of the most recent Tweets (truncated by default) and retweets posted by the authenticating user and the users they follow. The home timeline is central to how most users interact with the Twitter service.
 	 *
 	 * Parameters :
 	 * - count (1-200)
@@ -52,6 +54,7 @@ Trait StatusTrait {
 	 * - exclude_replies (0|1)
 	 * - contributor_details (0|1)
 	 * - include_entities (0|1)
+	 * - tweet_mode ('extended' returns a collection of Tweets, which are not truncated)
 	 */
 	public function getHomeTimeline($parameters = [])
 	{
@@ -68,6 +71,7 @@ Trait StatusTrait {
 	 * - trim_user (0|1)
 	 * - include_entities (0|1)
 	 * - include_user_entities (0|1)
+	 * - tweet_mode ('extended' returns a collection of Tweets, which are not truncated)
 	 */
 	public function getRtsTimeline($parameters = [])
 	{
@@ -94,6 +98,7 @@ Trait StatusTrait {
 	 * - trim_user (0|1)
 	 * - include_my_retweet (0|1)
 	 * - include_entities (0|1)
+	 * - tweet_mode ('extended' returns a collection of Tweets, which are not truncated)
 	 */
 	public function getTweet($id, $parameters = [])
 	{
@@ -170,10 +175,9 @@ Trait StatusTrait {
 	}
 
 	/**
-	 * Returns a single Tweet, specified by either a Tweet web URL or the Tweet ID, in an oEmbed-compatible format. The returned HTML snippet will be automatically recognized as an Embedded Tweet when Twitter’s widget JavaScript is included on the page.
+	 * Returns a single Tweet, specified by a Tweet web URL, in an oEmbed-compatible format. The returned HTML snippet will be automatically recognized as an Embedded Tweet when Twitter’s widget JavaScript is included on the page.
 	 *
 	 * Parameters :
-	 * - id
 	 * - url
 	 * - maxwidth (250-550)
 	 * - hide_thread (0|1)
@@ -181,15 +185,21 @@ Trait StatusTrait {
 	 * - align (left|right|center|none)
 	 * - related (twitterapi|twittermedia|twitter)
 	 * - lang
+	 * - theme (dark|light)
+	 * - link_color (hex value)
+	 * - widget_type (video)
 	 */
 	public function getOembed($parameters = [])
 	{
-		if (!array_key_exists('id', $parameters) && !array_key_exists('url', $parameters))
+		if (!array_key_exists('url', $parameters))
 		{
-			throw new BadMethodCallException('Parameter required missing : id or url');
+			throw new BadMethodCallException('Parameter required missing : url');
 		}
 
-		return $this->get('statuses/oembed', $parameters);
+		$this->tconfig['API_URL'] = 'publish.twitter.com';
+		$this->tconfig['API_VERSION'] = '';
+
+		return $this->get('oembed', $parameters, false, '');
 	}
 
 	/**
@@ -218,6 +228,7 @@ Trait StatusTrait {
 	 * - include_entities (0|1)
 	 * - trim_user (0|1)
 	 * - map (0|1)
+	 * - tweet_mode ('extended' returns a collection of Tweets, which are not truncated)
 	 */
 	public function getStatusesLookup($parameters = [])
 	{

--- a/src/Thujohn/Twitter/Twitter.php
+++ b/src/Thujohn/Twitter/Twitter.php
@@ -50,7 +50,10 @@ class Twitter extends tmhOAuth {
 	 * Only for debugging
 	 */
 	private $debug;
+
 	private $log = [];
+
+	private $error;
 
 	public function __construct(Config $config, SessionStore $session)
 	{
@@ -260,12 +263,14 @@ class Twitter extends tmhOAuth {
 
 		$this->log('FORMAT : '.$format);
 
-		$this->error = $response['error'];
+		$error = $response['error'];
 
-		if ($this->error)
+		if ($error)
 		{
 			$this->log('ERROR_CODE : '.$response['errno']);
 			$this->log('ERROR_MSG : '.$response['error']);
+
+			$this->setError($response['errno'], $response['error']);
 		}
 
 		if (isset($response['code']) && ($response['code'] < 200 || $response['code'] > 206))
@@ -293,6 +298,8 @@ class Twitter extends tmhOAuth {
 
 			$this->log('ERROR_CODE : '.$error_code);
 			$this->log('ERROR_MSG : '.$error_msg);
+
+			$this->setError($error_code, $error_msg);
 
 			throw new RunTimeException('['.$error_code.'] '.$error_msg, $response['code']);
 		}
@@ -442,6 +449,18 @@ class Twitter extends tmhOAuth {
 	public function linkReply($tweet)
 	{
 		return 'https://twitter.com/intent/tweet?in_reply_to=' . $tweet->id_str;
+	}
+	
+	public function error()
+	{
+		return $this->error;
+	}
+	
+	public function setError($code, $message)
+	{
+		$this->error = compact('code', 'message');
+
+		return $this;
 	}
 
 	private function jsonDecode($json, $assoc = false)

--- a/src/Thujohn/Twitter/Twitter.php
+++ b/src/Thujohn/Twitter/Twitter.php
@@ -224,7 +224,7 @@ class Twitter extends tmhOAuth {
 		}
 	}
 
-	public function query($name, $requestMethod = 'GET', $parameters = [], $multipart = false)
+	public function query($name, $requestMethod = 'GET', $parameters = [], $multipart = false, $extension = 'json')
 	{
 		$this->config['host'] = $this->tconfig['API_URL'];
 
@@ -233,7 +233,7 @@ class Twitter extends tmhOAuth {
 			$this->config['host'] = $this->tconfig['UPLOAD_URL'];
 		}
 
-		$url = parent::url($this->tconfig['API_VERSION'].'/'.$name);
+		$url = parent::url($this->tconfig['API_VERSION'].'/'.$name, $extension);
 
 		$this->log('METHOD : '.$requestMethod);
 		$this->log('QUERY : '.$name);
@@ -311,9 +311,9 @@ class Twitter extends tmhOAuth {
 		return $response;
 	}
 
-	public function get($name, $parameters = [], $multipart = false)
+	public function get($name, $parameters = [], $multipart = false, $extension = 'json')
 	{
-		return $this->query($name, 'GET', $parameters, $multipart);
+		return $this->query($name, 'GET', $parameters, $multipart, $extension);
 	}
 
 	public function post($name, $parameters = [], $multipart = false)


### PR DESCRIPTION
Use the Twitter publish resource for oEmbed requests, because it is not rate limited and add important documentation on some parameters for Tweet-retrieval (Tweets are truncated by default now).

Related links:
https://dev.twitter.com/rest/reference/get/statuses/oembed
https://dev.twitter.com/overview/api/upcoming-changes-to-tweets#overview

Thanks for this library!