### PR TITLE
Fix post dm

### DIFF
--- a/src/Thujohn/Twitter/Traits/DirectMessageTrait.php
+++ b/src/Thujohn/Twitter/Traits/DirectMessageTrait.php
@@ -77,7 +77,7 @@ Trait DirectMessageTrait {
 	 */
 	public function postDm($parameters = [])
 	{
-		if ((!array_key_exists('user_id', $parameters) && !array_key_exists('screen_name', $parameters)) || !array_key_exists('text', $parameters))
+		if ((!array_key_exists('user_id', $parameters) || !array_key_exists('screen_name', $parameters)) && !array_key_exists('text', $parameters))
 		{
 			throw new BadMethodCallException('Parameter required missing : user_id, screen_name or text');
 		}


### PR DESCRIPTION
The user_id and screen_name are optional (Only one of them is required).
And the text is required.
Reference:
https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/new-message

Thanks for your awesome package.